### PR TITLE
Properly calculate length for encrypted packets

### DIFF
--- a/sr-dissector.lua
+++ b/sr-dissector.lua
@@ -17,6 +17,10 @@ function silkroad_protocol.dissector(buffer, pinfo, tree)
 	local security = buffer(4,2)
 	
 	local is_encrypted = buffer(1,1):bitfield(0,1) == 1
+	if is_encrypted then
+		local size_encrypted = size:le_uint()
+		size = size_encrypted - 0x8000
+	end
 	
 	pinfo.cols.protocol = "Silkroad"
 	


### PR DESCRIPTION
Given the size also contains the encrypted bit, the size displayed for encrypted packets is a little too large and confusing to work with. If we know it's encrypted, we might as well remove the flag and get the proper contained size.